### PR TITLE
[PLAT-263] Peg dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 name = "ajuna-common"
 version = "0.1.0"
-source = "git+https://github.com/ajuna-network/Ajuna.git?branch=main#517fe3ac968fceabc0387e47ff3fef3c97aade46"
+source = "git+https://github.com/ajuna-network/Ajuna.git?rev=polkadot-v0.9.20#4b94816df69a9c6668ebb505f57e864e03fdc01a"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -1269,7 +1269,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "pallet-ajuna-connectfour"
 version = "0.1.0"
-source = "git+https://github.com/ajuna-network/Ajuna.git?branch=main#517fe3ac968fceabc0387e47ff3fef3c97aade46"
+source = "git+https://github.com/ajuna-network/Ajuna.git?rev=polkadot-v0.9.20#4b94816df69a9c6668ebb505f57e864e03fdc01a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1284,7 +1284,7 @@ dependencies = [
 [[package]]
 name = "pallet-ajuna-matchmaker"
 version = "0.1.0"
-source = "git+https://github.com/ajuna-network/Ajuna.git?branch=main#517fe3ac968fceabc0387e47ff3fef3c97aade46"
+source = "git+https://github.com/ajuna-network/Ajuna.git?rev=polkadot-v0.9.20#4b94816df69a9c6668ebb505f57e864e03fdc01a"
 dependencies = [
  "ajuna-common",
  "frame-support",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -48,7 +48,7 @@ sp-version = { version = "5.0.0", default-features = false, git = "https://githu
 pallet-parentchain = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.20" }
 
 # Ajuna dependencies
-pallet-ajuna-connectfour = { default-features = false, git = "https://github.com/ajuna-network/Ajuna.git", branch = "main" }
+pallet-ajuna-connectfour = { default-features = false, git = "https://github.com/ajuna-network/Ajuna.git", rev = "polkadot-v0.9.20" }
 pallet-scheduler = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.20" }
 
 [features]


### PR DESCRIPTION
Re: [PLAT-263](https://ajunanetwork.atlassian.net/browse/PLAT-263)

There are a couple of upstream dependencies that point to `master`, which we will ignore for now as will be handled by the upstream:

- https://github.com/apache/teaclave-sgx-sdk
- https://github.com/haerdib/incubator-teaclave-sgx-sdk